### PR TITLE
Correct various typos in the vignettes

### DIFF
--- a/vignettes/FAQ.rmd
+++ b/vignettes/FAQ.rmd
@@ -39,7 +39,7 @@ A. With the 24/96 column formats it ignores the 25th hour of fall back and treat
 
 **Q. In the standard meter data format what hour does each column correspond to?**
 
-A. Your column headers don't have to match these, but referring to the TestData output, the first column, H1, is 12-1am (i.e. the averag eof consumption up to but excluding 1am) so H10 is 9-10am, and h24 is 11pm-12am.
+A. Your column headers don't have to match these, but referring to the TestData output, the first column, H1, is 12-1am (i.e. the average of consumption up to but excluding 1am) so H10 is 9-10am, and h24 is 11pm-12am.
 
 ***
 
@@ -69,7 +69,7 @@ A. If you hoping to load data directly from CSVs or RData or something, you are 
 
 **Q. Load Shape Clustering: Is the clustering profile library rich enough to expect it to perform well on customer data that includes also industrial customers and streetlighting.**
 
-A. First of all, the load shape clustering algorithms are protected by a patent and are therefore available separately from the rest of the VISDOM code. You need to ask for permission to work with that code, but non-commercial licensing is free. As for separating data for clsutering, this depends on your intended use. Typically you would separate residential, commerical, industry, etc. and fit clusters separately. Even within commercial there is so much diversity of use that it can be good to do separate fits for each sub type (i.e. NAICS or other codes).
+A. First of all, the load shape clustering algorithms are protected by a patent and are therefore available separately from the rest of the VISDOM code. You need to ask for permission to work with that code, but non-commercial licensing is free. As for separating data for clustering, this depends on your intended use. Typically you would separate residential, commercial, industry, etc. and fit clusters separately. Even within commercial there is so much diversity of use that it can be good to do separate fits for each sub type (i.e. NAICS or other codes).
 
 ***
 

--- a/vignettes/authoring_data_source.rmd
+++ b/vignettes/authoring_data_source.rmd
@@ -11,9 +11,9 @@ vignette: >
 
 #Implementing your own data source
 
-In VISDOM, a data source is an adapter between your customer and meter data and the internal data formats used by VISDOM functions. To use VISDOM with your own data, you will need to author a DataSource object that maps between the formatting of your data and the data structures used by VISDOM by implementing all the relevant functions stubbed out by `DataSource()` in `util-dataSource.R`. This is the key step and main pre-requsite for using VISDOM. You will typically need to set up data access (i.e. to a SQL database if applicable - see `util-dbUtil.R` - or figure out how you will be loading your data from disk or elsewhere), and write the code to perform the queries or other data access steps as appropriate to load, format, and return your data in the VISDOM standard format expected to come out of a data source. You can see the DataSource implemented for testing purposes in the file `testDataSource.R` in the R directory of the package.
+In VISDOM, a data source is an adapter between your customer and meter data and the internal data formats used by VISDOM functions. To use VISDOM with your own data, you will need to author a DataSource object that maps between the formatting of your data and the data structures used by VISDOM by implementing all the relevant functions stubbed out by `DataSource()` in `util-dataSource.R`. This is the key step and main prerequisite for using VISDOM. You will typically need to set up data access (i.e. to a SQL database if applicable - see `util-dbUtil.R` - or figure out how you will be loading your data from disk or elsewhere), and write the code to perform the queries or other data access steps as appropriate to load, format, and return your data in the VISDOM standard format expected to come out of a data source. You can see the DataSource implemented for testing purposes in the file `testDataSource.R` in the R directory of the package.
 
-Setting the global varaible `DATA_SOURCE = YourDataSource()` configures your data source for use by VISDOM (i.e. assign it to the global variable DATA_SOURCE).
+Setting the global variable `DATA_SOURCE = YourDataSource()` configures your data source for use by VISDOM (i.e. assign it to the global variable DATA_SOURCE).
 
 See the entry for the data parameter in the help for MeterDataClass:
 
@@ -58,7 +58,7 @@ head(weather,2)
 dim(weather)
 ```
 
-4. Misc capabilites
+4. Misc capabilities
 
 ```{r geo_attributes}
 DATA_SOURCE$getGeoForId('meter_1')

--- a/vignettes/bootstrap_devel_environment.rmd
+++ b/vignettes/bootstrap_devel_environment.rmd
@@ -49,7 +49,7 @@ devtools::install_github("hadley/devtools")
 
 #Install VISDOM as a local package from your source
 
-Ensure that your getwd() is the vsidom source dir and then call:
+Ensure that your getwd() is the visdom source dir and then call:
 
 ```{r eval=F}
 devtools::document()
@@ -60,7 +60,7 @@ devtools::build_vignettes()
 
 ```
 
-Followed by installing hte package from source, which should resolve and install all the package dependencies,
+Followed by installing the package from source, which should resolve and install all the package dependencies,
 with some exceptions, like for HDF5 support.
 
 ```{r eval=F}

--- a/vignettes/example_feature_extraction.rmd
+++ b/vignettes/example_feature_extraction.rmd
@@ -21,7 +21,7 @@ library(plyr)
 
 ##Load your custom data source
 
-To use VISDOM, you must have a DataSource implementation that maps your source data to the VISDOM cannonical data formats for meter data, meter ids, weather data, etc. You configure VISDOM to use your DataSource by assigning the global variable DATA_SOURCE as an instance of it. For this example we are using the `TestData()` data source, defined in `testDataSource.R` that conforms to the data source interface requirements, but generates loosely structured synthetic data (with coarse diurnal and seasonal changes).
+To use VISDOM, you must have a DataSource implementation that maps your source data to the VISDOM canonical data formats for meter data, meter ids, weather data, etc. You configure VISDOM to use your DataSource by assigning the global variable DATA_SOURCE as an instance of it. For this example we are using the `TestData()` data source, defined in `testDataSource.R` that conforms to the data source interface requirements, but generates loosely structured synthetic data (with coarse diurnal and seasonal changes).
 
 
 ```{r}
@@ -60,7 +60,7 @@ dailyCP = DescriptorGenerator(  name='tout1CP',
                                 cvReps=8) # 1 CP
 ```
 
-The actual feature funciton calls `run()` in the generated descriptor, here called `dailyCP` to run the specified regression model, with optional cross-validation, etc. as specified in the call to DescriptorGenerator. The model parameters of interest are stored in the object returned by `run` under `other` values. We return these with the prefix `dailyCP_`, to distinguish them from any other model outputs we might generate from other models in the same feature run.
+The actual feature function calls `run()` in the generated descriptor, here called `dailyCP` to run the specified regression model, with optional cross-validation, etc. as specified in the call to DescriptorGenerator. The model parameters of interest are stored in the object returned by `run` under `other` values. We return these with the prefix `dailyCP_`, to distinguish them from any other model outputs we might generate from other models in the same feature run.
 
 ```{r}
 regressionFeaturesfn = function(cust,ctx,...) { # for future results
@@ -111,7 +111,7 @@ ctx$end.date   = as.Date('2011-10-15')
 
 ##Running the feature extraction itself
 
-The business end of feature extraction is the call to an interator method that is passed meter ids and rules for calling feature function on meter data objects created using the passed data. This single line, runs features on every customer in the list of ids (including all of them) by using the id's to instantiate `CustomerData` objects via the `DATA_SOURCE`. This can be called during feature development and for testing with just a handful of ids (as shown here), or with hundreds of thousands for running features on rich data sets. Note that as a practical matter, the latter call (on large samples of customers) would logically be called with better support for parallel processing and error failover than the simple `iterator.iterateMeters` function provides. This call returns a list of lists of features. So the outter list is indexed by customer id and there is a named list of feature for each customer.
+The business end of feature extraction is the call to an iterator method that is passed meter ids and rules for calling feature function on meter data objects created using the passed data. This single line, runs features on every customer in the list of ids (including all of them) by using the id's to instantiate `CustomerData` objects via the `DATA_SOURCE`. This can be called during feature development and for testing with just a handful of ids (as shown here), or with hundreds of thousands for running features on rich data sets. Note that as a practical matter, the latter call (on large samples of customers) would logically be called with better support for parallel processing and error failover than the simple `iterator.iterateMeters` function provides. This call returns a list of lists of features. So the outer list is indexed by customer id and there is a named list of feature for each customer.
 
 ```{r}
 aRunOut = iterator.iterateMeters( DATA_SOURCE$getIds()[1:10], # just 10 for speed
@@ -120,7 +120,7 @@ aRunOut = iterator.iterateMeters( DATA_SOURCE$getIds()[1:10], # just 10 for spee
                                   extra='somedata')
 ```
 
-A list of lists is returned because it is maximally flexible. Some feature functions may opt to return diagnostic, error, residual, model, etc. data that are not scalar features, but have values in diagnosing problems, testing hypotheses, etc. To boild the list of lists down to a data frame of the scalar feature values, we call the utility function `iterator.todf()`.
+A list of lists is returned because it is maximally flexible. Some feature functions may opt to return diagnostic, error, residual, model, etc. data that are not scalar features, but have values in diagnosing problems, testing hypotheses, etc. To boil the list of lists down to a data frame of the scalar feature values, we call the utility function `iterator.todf()`.
 
 ```{r}
 runDF = iterator.todf( aRunOut )
@@ -200,7 +200,7 @@ aRunOut = plyr::alply(  .data = DATA_SOURCE$getIds(),
 
 ###Alternate 1 (eliminating redundant data access with or without parallelization):
 
-Note that one performance optimization that is pretty common when processing large numbers of meters is to load weather data for one location and process all meters from that location with the weather data and all relevant meter data cached in the ctx. This can be a bigger performance boost than naively running each customer in parallel, where data access will redundantly happen over and over. In this case, you might run alply across zip codes, calling a function that loads weather data and all customer data for that zip code, places them both into the ctx and then calls alply with all the customer ids for that zipcode (the underlying code looks in the ctx for weather data and customer data). Technically, this function does not exist. The "official" support for processing customers by zip code is in `iterator.iterateZip`, which is implemented using standard for loops, but it should be pretty clear from that what to do next if you want a parallelizable version.
+Note that one performance optimization that is pretty common when processing large numbers of meters is to load weather data for one location and process all meters from that location with the weather data and all relevant meter data cached in the ctx. This can be a bigger performance boost than naively running each customer in parallel, where data access will redundantly happen over and over. In this case, you might run alply across zip codes, calling a function that loads weather data and all customer data for that zip code, places them both into the ctx and then calls alply with all the customer ids for that zip code (the underlying code looks in the ctx for weather data and customer data). Technically, this function does not exist. The "official" support for processing customers by zip code is in `iterator.iterateZip`, which is implemented using standard for loops, but it should be pretty clear from that what to do next if you want a parallelizable version.
 
 ###Alternate 2 (subsetting meters using command line args):
 
@@ -208,7 +208,7 @@ In practice, users have often written a wrapper script that implements a form of
 
 ###Caveats:
 
-Note that as will all parallel operations, error handling is a bit tricky. `iterator.runMeter` traps errors and returns NAs after printing the error message so it can keep running. This allows the rest of the data to be processed. When running in parallel the place for print statements to output to is poorly defined, so users may never see the printed error message. Thus, you have to be extra careful to investigate any NAs values returned for any customers. In the future, we hope to architect infrastrucutre that allows storing and returning  error diagnostic information for each customer that has an error within the listof lists data structure, but for now parallel processing are related error handling is a partially unsupported "advanced" feature.
+Note that as will all parallel operations, error handling is a bit tricky. `iterator.runMeter` traps errors and returns NAs after printing the error message so it can keep running. This allows the rest of the data to be processed. When running in parallel the place for print statements to output to is poorly defined, so users may never see the printed error message. Thus, you have to be extra careful to investigate any NAs values returned for any customers. In the future, we hope to architect infrastructure that allows storing and returning  error diagnostic information for each customer that has an error within the listof lists data structure, but for now parallel processing are related error handling is a partially unsupported "advanced" feature.
 
 Also note that other than the error trapping, the official VISDOM code doesn't support mid-stream failures very gracefully. Ideally users would have the option of incrementally saving out results so they can recover from any fatal errors that could cause them to lose valid features built up in memory (or so that they can fill in NAs caused by errors without re-running all the good results). Parallel jobs tend to be all or nothing in their return values and can toss out viable computed values due to a data frame column name incompatibility or other minor issue compiling results. In the past VISDOM users have created scripted options for saving each zip code worth of features and also for savings lists of meters whose validation rules eliminated them from processing to save time re-processing good data over and over due to later failures and re-validating meters over and over. We may provide suitable official versions of these capabilities via the `iterator.R` functions in the future, but advanced users should currently plan to write their own iterators and wrappers if graceful failure is desired.
 

--- a/vignettes/example_iterator_usage.rmd
+++ b/vignettes/example_iterator_usage.rmd
@@ -4,7 +4,7 @@ author: "Sam Borgeson"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Woring With Samples from Many Meters}
+  %\VignetteIndexEntry{Working With Samples from Many Meters}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/install_visdom.rmd
+++ b/vignettes/install_visdom.rmd
@@ -11,7 +11,7 @@ vignette: >
 
 #Simplest approach
 
-There is support in R for installing and updating packages directly from their version control repositories. If you plan to use VISDOM without altering any of its soruce code, this is the preferred method of installation.
+There is support in R for installing and updating packages directly from their version control repositories. If you plan to use VISDOM without altering any of its source code, this is the preferred method of installation.
 
 ##Install VISDOM directly from GitHub source
 
@@ -29,7 +29,7 @@ devtools::install_github("convergenceda/visdom", build_vignettes=T )
 
 ##Install VISDOM directly from local source
 
-If you are planning to read through, experiment with, or update the VISDOM source code itself, you will want a local copy of the reopsitory on your machine. 
+If you are planning to read through, experiment with, or update the VISDOM source code itself, you will want a local copy of the repository on your machine. 
 
 First ensure that you have cloned the repository into working version only your local machine, choosing one of:
 
@@ -39,7 +39,7 @@ git clone git@github.com:convergenceda/visdom.git
 git clone https://github.com/convergenceda/visdom.git
 ```
 
-If you are working within a corporate firewall, it may be necessary to use a proxy server account to connect to GitHub. Here you will need to replace the user and pass with your usernam and password and `proxy.server` with either the name or ip address of your proxy server. The port `8080` may also be different for your specific configuration.
+If you are working within a corporate firewall, it may be necessary to use a proxy server account to connect to GitHub. Here you will need to replace the user and pass with your username and password and `proxy.server` with either the name or ip address of your proxy server. The port `8080` may also be different for your specific configuration.
 
 ```{bash eval=F}
 git config --global http.proxy http://user:pass@proxy.server:8080


### PR DESCRIPTION
There is one typo remaining “forIn” that I wasn’t sure how to fix; in example_feature_extraction.rmd under “Exporting your data”.